### PR TITLE
Trim comments from the end of configuration lines

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -13,6 +13,26 @@ int hyperKey;
 int keymap[256];
 
 /**
+ * @brief Trim comment from the end of the string started by '#' character.
+ *
+ * @param s String to be trimmed.
+ * @return char* Trimmed string without any comments.
+ */
+char* trimComment(char* s)
+{
+    if (s != NULL)
+    {
+        char *p  = strchr(s, '#');
+        if (p != NULL)
+        {
+            // p points to the start of the comment.
+            *p = '\0';
+        }
+    }
+    return s;
+}
+
+/**
  * Trims a string.
  * credit to chux: https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way#122721
  */
@@ -71,7 +91,7 @@ int isCommentOrEmpty(char* line)
 void findDeviceEvent(char* deviceConfigValue)
 {
     eventPath[0] = '\0';
-    
+
     char* deviceName = deviceConfigValue;
     int deviceNumber = getDeviceNumber(deviceName);
 
@@ -184,7 +204,8 @@ void readConfiguration()
     ssize_t result = -1;
     while ((result = getline(&buffer, &length, configFile)) != -1)
     {
-        char* line = trimString(buffer);
+        char* line = trimComment(buffer);
+        line = trimString(line);
 
         // Comment or empty line
         if (isCommentOrEmpty(line)) continue;


### PR DESCRIPTION
### Reason for this feature
I have multiple devices using [the same customized config file](https://github.com/Adda0/dotfiles/blob/master/home/.config/touchcursor/touchcursor.conf), so I need to set various keyboard names at once to let TouchCursor choose the currently plugged keyboard (which is supposed to work according to #12 issue). Because of that, I have separate `Name=` lines in `touchcursor.conf` config file and to remember which keyboard belongs to which device, I have added short comments at the end of their respective lines.

```sh
Name="BTC USB Multimedia Keyboard" # Main desktop keyboard.
Name="AT Translated Set 2 keyboard" # Notebook keyboard.
```

I have been surprised when TouchCursor stopped working after I added multiple `Name=` lines. By looking at the code, I realized the problem does not lie with the duplicated `Name=` lines, but with parsing of the comments at the end of any configuration lines (non-empty lines which are not just comment lines).
 
I believe the option to add comments at the end of configuration lines should be present, as it provides a useful way to better describe parts of custom TouchCursor configurations and explain specific configuration lines without the need to create a new line for every single comment.
 
### Solution
Look for one-line comments started by `#` at the end of any line when parsing the configuration lines, and trim such comments.

### Example
This PR allows correct parsing of configuration lines with comments at the end and keeps TouchCursor running without errors due to comments on the configuration lines. Comments can be appended at the end of any configuration line started by `#`, following at least a single whitespace after the corresponding configuration:
```regex
[^#]*\s+#.*
```

For example, the following will be parsed correctly.
```sh
[Device]
Name="BTC USB Multimedia Keyboard" # Main desktop keyboard.
Name="AT Translated Set 2 keyboard" # Notebook keyboard.

[Bindings] # This is the Bindings section, where you can remap keys to different one.
KEY_H=KEY_LEFT # You can use Vim-like keybindings for movement.
KEY_J=KEY_DOWN
KEY_K=KEY_UP
KEY_L=KEY_RIGHT
```

### Testing
I am using my version of TouchCursor with this PR included and everything has worked flawlessly so far.