### PR TITLE
Populate the virtual dev with only valid keybits

### DIFF
--- a/src/binding.c
+++ b/src/binding.c
@@ -83,8 +83,9 @@ int bindOutput()
         return EXIT_FAILURE;
     }
     // Enable the set of KEY events
-    // (I used to have < KEY_MAX here, but that seems to be causing issues?)
-    for (int i = 0; i <= 572; i++) 
+    // Add all keybits up to the constant KEY_INTERESTING, which the kernel defines it as the end of the set 
+    // of keybits that are common to keyboard devices.
+    for (int i = 0; i <= KEY_MIN_INTERESTING; i++)
     {
         int result = ioctl(output, UI_SET_KEYBIT, i);
         if (result < 0)


### PR DESCRIPTION
This fixes the issue where keyboard stops working under Gnome 41 (with wayland). 

The cause is that Gnome gets the virtual dev from logind, but logind has not recognized the virtual dev and it doesn't include it in its available input devices and it returns a ENODEV error:

```
gnome-shell[5643]: Could not open device /dev/input/event256: GDBus.Error:System.Error.ENODEV: No such device
```

Probably, the reason is because the virtual device contains keybits that are unusual and unrelated to keyboard keys (e.g., BTN_MOUSE, BTN_JOYSTICK, BTN_DPAD_UP, BTN_GEAR_DOWN, BTN_TOOL_PEN, BTN_TRIGGER_HAPPY and many others) and this can be verified by using `devadm info /dev/input/event256` where it includes the `ID_INPUT_MOUSE=1`  property along with the `ID_INPUT_KEYBOARD=1` which is confusing and unexpected.

In order to avoid this miscategorization, this fix sets only the common keyboard keybits to the virtual device (all keybits up to what the kernel defines as KEY_INTERESTING (see linux/input.h) which happens to be KEY_MUTE in kernel 5.10. This is probably the most common and compatible keybit set expected for a keyboard to have. Using this keybit set, the keyboard is successfully recognized as a keyboard and  the erroneous `ID_INPUT_MOUSE=1`  property is gone and is finally working fine under Gnome (wayland). I don't expect this to create any issues because it includes almost all possible keys a keyboard can have.