### PR TITLE
Replace magic number for maximal input event codes with a macro

### DIFF
--- a/src/binding.c
+++ b/src/binding.c
@@ -83,8 +83,7 @@ int bindOutput()
         return EXIT_FAILURE;
     }
     // Enable the set of KEY events
-    // (I used to have < KEY_MAX here, but that seems to be causing issues?)
-    for (int i = 0; i <= 572; i++) 
+    for (int i = 0; i <= MAX_KEYS_TO_ENABLE_KEY_EVENTS_HANDLING_FOR; i++)
     {
         int result = ioctl(output, UI_SET_KEYBIT, i);
         if (result < 0)

--- a/src/binding.h
+++ b/src/binding.h
@@ -1,6 +1,18 @@
 #ifndef binding_header
 #define binding_header
 
+/**
+ * @brief The highest input event code to enable key events handling for.
+ *
+ * There used to be KEY_MAX here, but that seems to be causing issues:
+ * At one point there was an issue where the virtual device could not be created
+ * if keys up to KEY_MAX (767) were included. 572 came from iterating down
+ * from KEY_MAX until things started working again. Not sure what the underlying
+ * cause is. For further reference, see
+ * https://github.com/donniebreve/touchcursor-linux/pull/39#issuecomment-1000901050.
+ */
+#define MAX_KEYS_TO_ENABLE_KEY_EVENTS_HANDLING_FOR 572
+
 extern int input;
 int bindInput(char* fileDescriptor);
 


### PR DESCRIPTION
### Reason for this pull request
I consider magic numbers in the code a bad practise. Magic numbers are confusing and error-prone. Furthermore, no one dares to touch them if they do not know all the information about the given magic number and its origin in fear of breaking something.

In a reaction to the discussion in [the last PR](https://github.com/donniebreve/touchcursor-linux/pull/39), I propose a replacement of the discussed magic number for maximal input event code with a macro. As a result, no one gets confused about the meaning of this value in the future and it saves some time for others trying to figure out what it stands for. 

### Solution
I suggest defining a macro `MAX_KEYS_TO_ENABLE_KEY_EVENTS_HANDLING_FOR`. The identifier itself describes exactly what is the purpose of this value in the source code while keeping in mind the original `MAX_KEYS` identifier, which we aim for. This macro replaces the aforementioned magic number `572` for maximal input event code handled by TouchCursor with a comment explaining what this magical `572` stands for and what it should be ideally instead, if there were no issues connected to `MAX_KEYS`.

At least until we solve the issue with `MAX_KEYS`, this solution should help keep the code readable and approachable to everyone.

### Testing
All tests from [test.c](https://github.com/donniebreve/touchcursor-linux/blob/main/src/test.c) pass. I am using my version of TouchCursor with this PR included and everything has worked flawlessly so far.
