### PR TITLE
Add a comment to the default config file reminding to restart the service

### DIFF
--- a/touchcursor.conf
+++ b/touchcursor.conf
@@ -1,5 +1,9 @@
 # Touch Cursor Linux configuration file
 
+# Do not forget to restart the TouchCursor service with
+# 'systemctl --user restart touchcursor.service'
+# after some changes to this config file are made to apply them.
+
 # Find this line using the following command
 # grep -E 'Name=|Handlers=|EV=' /proc/bus/input/devices | grep -B2 EV='120013' --no-group-separator | grep 'Name=' | cut -c 4-
 # If there are multiple devices with the same name, you may add :# to the line (ex: Name="Your Keyboard":2)


### PR DESCRIPTION
### Reason for this pull request
There have been a few issues reported where remembering to restart the TouchCursor service after some changes to the config file are made was the cause of the issue.

### Solution
Add a comment to the default config file reminding to restart the TouchCursor service after some changes to the config file are made to apply them.

### Testing
This PR should not break anything as it just adds a single comment to the config file. Furthermore, All tests from [test.c](https://github.com/donniebreve/touchcursor-linux/blob/main/src/test.c) pass. I am using my version of TouchCursor with this PR included and everything has worked flawlessly so far.