### PR TITLE
Improve and extend comments in config file

### DIFF
--- a/touchcursor.conf
+++ b/touchcursor.conf
@@ -10,18 +10,43 @@
 [Device]
 Name="Your Keyboard"
 
-# Permanent remappings
-#[Remap]
+# Remapping a key in both '[Remap]' and '[Bindings]' tables has a following format:
+# KEY_1=KEY_2
+# where KEY_1 is the key which is being remapped (the original key) and KEY_2 is the key KEY_1 will be remapped to.
+#
+# For usable key names, see: https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+
+# Permanent remappings.
+# Allows to set permanent remappings when running the service without a need to hold a hyper key pressed.
+# Each remapping will be active permanently when the service is running.
+#
+# The permamently remapped key can be remapped differently while holding the hyper key pressed in table `[Bindings]` with the original key name.
+# For example, key 't' will output 'm' when you are not holding the hyper key pressed and key 'd' when holding the hyper key pressed:
+# [Remap]
+# KEY_T=KEY_M
+# [Bindings]
+# KEY_T=KEY_D
+#
+# You can swap the functionality of two keys as follows:
+# [Remap]
+# KEY_T=KEY_M
+# KEY_M=KEY_T
+[Remap]
 #KEY_CAPSLOCK=KEY_LEFTCTRL
 
-# Hyper key
+# Hyper key.
+# Allows to set a hyper key to activate remappings in the table '[Bindings]' when holding the hyper key pressed.
 [Hyper]
 HYPER1=KEY_SPACE
 
-# KEY_1=KEY_2
-# https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+# Hyper key bindings.
+# The following bindings remap keys only when holding a hyper key pressed.
+#
+# For example, when holding the hyper key pressed, key 't' would output key 'k':
+# [Bindings]
+# KEY_T=KEY_K
 [Bindings]
-# Default bindings for IJKLHNUOMPY
+# Default bindings for IJKLHNUOMPY.
 KEY_I=KEY_UP
 KEY_J=KEY_LEFT
 KEY_K=KEY_DOWN


### PR DESCRIPTION
This PR improves and extends comments in the configuration file, as discussed in #47.

When we have two different tables (`[Remap]` and `[Bindings]`) which allow remapping of keys, we need to make sure users understand which table is used for which type of remapping (permanent or with hyper key).

The comments explain the used format for remapping, what is the purpose of each table, and show a few examples with explanation of what happens in the examples.