### PR TITLE
remove the extra delay to repeat after pressing and holding a mapped key

### DIFF
--- a/src/touchcursor.c
+++ b/src/touchcursor.c
@@ -90,6 +90,7 @@ void processKey(int type, int code, int value)
                 {
                     state = delay;
                     enqueue(code);
+                    emit(EV_KEY, convert(code), value); // emit the mapped key immediately to avoid an extra delay
                 }
                 else
                 {


### PR DESCRIPTION
When pressing and holding down the hyperkey and then pressing and holding a mapped key there is a small delay until the mapped keycode is emitted.

This is most evident with the Delay Interval before starting the Key Repeating. i.e.:

Assuming a configured system Interval Key Delay of 250ms.

1. press and hold down an arrow key, notice the time it takes to start repeating. 
2. now press and hold the hyperkey of touchcursor
3. while holding the hyperkey, press and hold the same arrow key as above, to start repeating

expected result:
One key event is emitted and the cursor moves once immediately, then the repeating events of the key start after the system's Interval Key Delay e.g. 250ms.

actual result:
**NO** key event is emitted and the cursor **doesn't move** at all. Repeating key events start a noticeable bit longer than the system's Interval Key Delay. e.g., 300-400ms instead of 250ms.

This PR removes this extra delay and is on par as with the real keys.