### PR TITLE
Remove released keys from queue.

### DIFF
--- a/src/mapper.c
+++ b/src/mapper.c
@@ -44,6 +44,10 @@ static void send_mapped_key(int code, int value)
         }
         emit(EV_KEY, output.sequence[i], value);
     }
+    if (value == 0)
+    {
+        removeKeyFromQueue(code);
+    }
 }
 
 /**
@@ -68,6 +72,10 @@ static void send_remapped_key(int code, int value)
         code = remap[code];
     }
     emit(EV_KEY, code, value);
+    if (value == 0)
+    {
+        removeKeyFromQueue(code);
+    }
 }
 
 /**

--- a/src/queue.c
+++ b/src/queue.c
@@ -18,6 +18,7 @@ void clearQueue()
     {
         store[i] = 0;
     }
+    head = tail = 0;
 }
 
 /**
@@ -73,4 +74,33 @@ int peek()
         return 0;
     }
     return store[head];
+}
+
+/**
+ * Remove key from the queue.
+ * */
+void removeKeyFromQueue(int value)
+{
+    for (int i = head; i != tail; i = (i + 1) % length)
+    {
+        if (store[i] == value)
+        {
+            if (i == head)
+            {
+                head = (head + 1) % length;
+            }
+            else
+            {
+                if (i != tail)
+                {
+                    for (int j = (i + 1) % length; j != tail; j = (j + 1) % length, i++)
+                    {
+                        store[i] = store[j];
+                    }
+                }
+                tail = (length + tail - 1) % length;
+            }
+            return;
+        }
+    }
 }

--- a/src/queue.h
+++ b/src/queue.h
@@ -26,4 +26,9 @@ int dequeue();
  * */
 int peek();
 
+/**
+ * Remove key from the queue.
+ * */
+void removeKeyFromQueue(int value);
+
 #endif


### PR DESCRIPTION
Upon release, the key is removed from queue, and keys later in the queue are shifted to allow the slot to be reused. This avoids sending a second release event for released keys when the hyper key is released. It also fixes an issue where the queue can fill with released keys, preventing a 9th key from being queued.