### PR TITLE
Automatic addition of all current keyboards during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,16 @@ install:
 	cp --force $(service) $(SERVICEPATH)
 	@echo ""
 
+	@echo "# Do you want to add the configuration with current all keyboards?(y/N)"
+	@read -r answer; \
+	if [ "$$answer" = "y" ] || [ "$$answer" = "Y" ]; then \
+		echo "\nUpdating configuration with all keyboards..."; \
+		bash ./scripts/update_conf_with_all_keyboards.sh; \
+	else \
+		echo "\nSkipping update conf"; \
+	fi
+	@echo ""
+	
 	@echo "# Copying default configuration file to $(CONFIGPATH)/$(config)"
 	mkdir --parents $(CONFIGPATH)
 	-cp --no-clobber $(config) $(CONFIGPATH)

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ install:
 	@echo "# Do you want to add all currently connected keyboards to your configuration? (y/N)"
 	@read -r answer; \
 	if [ "$$answer" = "y" ] || [ "$$answer" = "Y" ]; then \
-		echo "\nUpdating configuration..."; \
+		echo ""; \
+		echo "Updating configuration..."; \
 		bash ./scripts/update_conf_with_all_keyboards.sh $(CONFIGPATH)/$(config); \
 	fi
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,11 @@ install:
 	-cp --no-clobber $(config) $(CONFIGPATH)
 	@echo ""
 
-	@echo "# Do you want to add the configuration with current all keyboards?(y/N)"
+	@echo "# Do you want to add all currently connected keyboards to your configuration? (y/N)"
 	@read -r answer; \
 	if [ "$$answer" = "y" ] || [ "$$answer" = "Y" ]; then \
-		echo "\nUpdating configuration with all keyboards..."; \
+		echo "\nUpdating configuration..."; \
 		bash ./scripts/update_conf_with_all_keyboards.sh $(CONFIGPATH)/$(config); \
-	else \
-		echo "\nSkipping update conf"; \
 	fi
 	@echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -75,20 +75,20 @@ install:
 	mkdir --parents $(SERVICEPATH)
 	cp --force $(service) $(SERVICEPATH)
 	@echo ""
+	
+	@echo "# Copying default configuration file to $(CONFIGPATH)/$(config)"
+	mkdir --parents $(CONFIGPATH)
+	-cp --no-clobber $(config) $(CONFIGPATH)
+	@echo ""
 
 	@echo "# Do you want to add the configuration with current all keyboards?(y/N)"
 	@read -r answer; \
 	if [ "$$answer" = "y" ] || [ "$$answer" = "Y" ]; then \
 		echo "\nUpdating configuration with all keyboards..."; \
-		bash ./scripts/update_conf_with_all_keyboards.sh; \
+		bash ./scripts/update_conf_with_all_keyboards.sh $(CONFIGPATH)/$(config); \
 	else \
 		echo "\nSkipping update conf"; \
 	fi
-	@echo ""
-	
-	@echo "# Copying default configuration file to $(CONFIGPATH)/$(config)"
-	mkdir --parents $(CONFIGPATH)
-	-cp --no-clobber $(config) $(CONFIGPATH)
 	@echo ""
 
 	@echo "# Enabling and starting the service"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ y - insert
 1. Clone or download this repo
 2. 'make' to build the application
 3. 'make install' to install the application
+4. To add all your current keyboards to the configuration, type 'y' when prompted.
 5. Modify the config file (`~/.config/touchcursor/touchcursor.conf`) to your liking
 6. Restart the service `systemctl --user restart touchcursor.service`
 

--- a/scripts/update_conf_with_all_keyboards.sh
+++ b/scripts/update_conf_with_all_keyboards.sh
@@ -9,7 +9,7 @@ fi
 
 CONFIG_FILE="$1"
 
-# Set permissions to allow read and write for all users
+# Set permissions to allow write for owner and read for others
 chmod 644 "$CONFIG_FILE"
 
 # Check if the config file exists

--- a/scripts/update_conf_with_all_keyboards.sh
+++ b/scripts/update_conf_with_all_keyboards.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-CONFIG_FILE="touchcursor.conf"
+
+# Check if an argument is provided
+if [ $# -eq 0 ]; then
+    echo "Error: No configuration file specified."
+    echo "Usage: $0 <path_to_config_file>"
+    exit 1
+fi
+
+CONFIG_FILE="$1"
 
 # Set permissions to allow read and write for all users
 chmod 644 "$CONFIG_FILE"

--- a/scripts/update_conf_with_all_keyboards.sh
+++ b/scripts/update_conf_with_all_keyboards.sh
@@ -66,7 +66,7 @@ if [ -s "$TEMP_FILE" ] && [ -r "$TEMP_FILE" ]; then
     mv "$TEMP_FILE" "$CONFIG_FILE"
     chmod 644 "$CONFIG_FILE"
     
-    echo "Global configuration in $CONFIG_FILE has been updated."
+    echo "Configuration ($CONFIG_FILE) has been updated."
     echo "A backup of the original configuration has been saved as ${CONFIG_FILE}.bak"
     echo "All keyboard devices have been added to the [Device] section."
 else

--- a/scripts/update_conf_with_all_keyboards.sh
+++ b/scripts/update_conf_with_all_keyboards.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+CONFIG_FILE="touchcursor.conf"
+
+# Set permissions to allow read and write for all users
+chmod 644 "$CONFIG_FILE"
+
+# Check if the config file exists
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: $CONFIG_FILE does not exist. Please create a basic configuration file first."
+    exit 1
+fi
+
+# Create a temporary file
+TEMP_FILE=$(mktemp)
+
+# Function to get all keyboard device names
+get_keyboard_names() {
+    grep -E 'Name=|Handlers=|EV=' /proc/bus/input/devices | 
+    grep -B2 'EV=120013' --no-group-separator | 
+    grep 'Name=' | 
+    cut -d= -f2- | 
+    sed 's/"//g' |
+    sed 's/^[[:space:]]*//' |
+    sed 's/[[:space:]]*$//'
+}
+
+# Process the configuration file
+{
+    device_section_found=false
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ $line == "[Device]" ]]; then
+            echo "$line"
+            # Insert all keyboard devices
+            while IFS= read -r device_name; do
+                echo "Name=\"$device_name\""
+            done < <(get_keyboard_names)
+
+            device_section_found=true
+        elif $device_section_found && [[ $line == Name=* ]]; then
+            # Skip original device configurations
+            continue
+        elif [[ $line == "["*"]" ]]; then
+            # Reset flag when a new section is found
+            device_section_found=false
+            echo "$line"
+        else
+            echo "$line"
+        fi
+    done < "$CONFIG_FILE"
+} > "$TEMP_FILE"
+
+# Check if the temporary file is not empty and is readable
+if [ -s "$TEMP_FILE" ] && [ -r "$TEMP_FILE" ]; then
+    # Create a backup of the original file
+    cp "$CONFIG_FILE" "${CONFIG_FILE}.bak"
+    
+    # Replace the original file with the modified content
+    mv "$TEMP_FILE" "$CONFIG_FILE"
+    chmod 644 "$CONFIG_FILE"
+    
+    echo "Global configuration in $CONFIG_FILE has been updated."
+    echo "A backup of the original configuration has been saved as ${CONFIG_FILE}.bak"
+    echo "All keyboard devices have been added to the [Device] section."
+else
+    echo "Error: Failed to update the configuration. The original file has not been modified."
+    rm "$TEMP_FILE"
+    exit 1
+fi


### PR DESCRIPTION
Changes:
- Added Script file `/scripts/update_conf_with_all_keyboards.sh`
- During `make install`, if the user agrees, the script modifies `~/.config/touchcursor/touchcursor.conf`
- The default option is 'N'. (To prevent accidental config changes.)
- Configuration is updated based on CONFIGPATH and CONFIG variables 

Script
- Only the [Keyboard] section is modified.
- If the script is run, it will create a backup of the conf file as `~/.config/touchcursor/touchcursor.conf.bak`

Requirements:
- Bash is required for script execution.

![image](https://github.com/user-attachments/assets/74b33838-4f55-4f99-a14c-b2aa0a646e49)
