### PR TITLE
feat: add auto-restart to systemd service

### DIFF
--- a/touchcursor.service
+++ b/touchcursor.service
@@ -3,6 +3,8 @@ Description=Touch Cursor Service
 
 [Service]
 ExecStart=/usr/bin/touchcursor
+Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Add `Restart=always` and `RestartSec=3` to the service unit so touchcursor automatically recovers from unexpected crashes without manual intervention.

Note: @donniebreve  I love this tool, thanks!